### PR TITLE
Add basic Scene management

### DIFF
--- a/client/src/engine/SceneManager.ts
+++ b/client/src/engine/SceneManager.ts
@@ -1,0 +1,54 @@
+export abstract class Scene {
+  abstract load(): void
+
+  abstract unload(): void
+
+  abstract update(frameTime: DOMHighResTimeStamp): void
+
+  protected abstract draw(): void
+}
+
+type SceneList = {
+  [name: string]: Scene
+}
+
+export class SceneManager {
+  private _scenes: SceneList = {}
+
+  private _currentScene: Scene
+
+  public addScene(sceneName: string, scene: Scene): void {
+    this._scenes[sceneName] = scene
+  }
+
+  public removeScene(sceneName: string): void {
+    delete this._scenes[sceneName]
+  }
+
+  public switchScene(sceneName: string): void {
+    if (this._currentScene !== undefined) {
+      this._currentScene.unload()
+    }
+
+    if (this._scenes[sceneName] !== undefined) {
+      this._currentScene = this._scenes[sceneName]
+      this._currentScene.load()
+    }
+  }
+
+  public get currentScene(): Scene {
+    return this._currentScene
+  }
+
+  private static _instance: SceneManager
+
+  private constructor() {}
+
+  public static get instance(): SceneManager {
+    if (this._instance === undefined) {
+      this._instance = new SceneManager()
+    }
+
+    return this._instance
+  }
+}

--- a/client/src/game/Game.ts
+++ b/client/src/game/Game.ts
@@ -1,5 +1,6 @@
+import { SceneManager } from '../engine/SceneManager'
 import { HasLifecycle, IHasLifecycle } from '../engine/behavior/HasLifecycle'
-import { Field } from './Field'
+import { Field } from './scenes/Field'
 
 export class Game extends HasLifecycle implements IHasLifecycle {
   protected field: Field
@@ -9,10 +10,11 @@ export class Game extends HasLifecycle implements IHasLifecycle {
   }
 
   awake() {
-    this.field = new Field('#canvas')
+    SceneManager.instance.addScene('Field', new Field('#canvas'))
+    SceneManager.instance.switchScene('Field')
   }
 
   update(frameTime: DOMHighResTimeStamp) {
-    this.field.update(frameTime)
+    SceneManager.instance.currentScene.update(frameTime)
   }
 }

--- a/client/src/game/scenes/Field.ts
+++ b/client/src/game/scenes/Field.ts
@@ -1,10 +1,11 @@
-import { AbstractShape } from './shapes/AbstractShape'
-import { Coordinate } from './shapes/Coordinate'
-import { IHasLifecycle } from '../engine/behavior/HasLifecycle'
-import { InputManager } from '../engine/InputManager'
-import { ShapeList } from './shapes/ShapeList'
+import { AbstractShape } from '../shapes/AbstractShape'
+import { Coordinate } from '../shapes/Coordinate'
+import { IHasLifecycle } from '../../engine/behavior/HasLifecycle'
+import { InputManager } from '../../engine/InputManager'
+import { ShapeList } from '../shapes/ShapeList'
+import { Scene } from '../../engine/SceneManager'
 
-export class Field implements IHasLifecycle {
+export class Field extends Scene implements IHasLifecycle {
   static readonly CELL_SIZE: number = 20
 
   public width: number
@@ -24,13 +25,24 @@ export class Field implements IHasLifecycle {
   protected shapeList: ShapeList = new ShapeList()
 
   constructor(canvasSelector: string) {
+    super()
+
     const element: HTMLCanvasElement = document.querySelector(canvasSelector)
     this.ctx = element.getContext('2d')
 
     this.height = element.height
     this.width = element.width
+  }
 
+  public load() {
     this.spawnShape()
+  }
+
+  public unload() {
+    this.lastDrawnFrame = 0
+    this.lastKeyFrame = 0
+    this._fixedShapes = []
+    this._activeShape = null
   }
 
   public update(frameTime: DOMHighResTimeStamp) {

--- a/client/src/game/shapes/AbstractShape.ts
+++ b/client/src/game/shapes/AbstractShape.ts
@@ -1,5 +1,5 @@
 import { Coordinate } from './Coordinate'
-import { Field } from '../Field'
+import { Field } from '../scenes/Field'
 import { Cell } from './Cell'
 
 export abstract class AbstractShape {


### PR DESCRIPTION
Adds a singleton `SceneManager` class to the engine, with following methods:

* `addScene` to add a class that inherits from `Scene` to the list of scenes with a name
* `removeScene` to remove scenes by name
* `switchScene` to switch to another scene by name
  * if a previous scene has been active `unload()` will be called on it (destructuring/deinitialization)
  * the new loaded scene will have `load()` called after being switched to
* `currentScene` as property is the currently active scene